### PR TITLE
feat: expose Firebase SDK exports & log appId in notification wrapper

### DIFF
--- a/lib/flutter_notification_wrapper.dart
+++ b/lib/flutter_notification_wrapper.dart
@@ -27,6 +27,12 @@
 /// ```
 library flutter_notification_wrapper;
 
+// External packages
+
+export 'package:firebase_analytics/firebase_analytics.dart';
+export 'package:firebase_core/firebase_core.dart';
+export 'package:firebase_messaging/firebase_messaging.dart';
+
 export '../src/background_message_handler.dart';
 export '../src/default_notification_handler.dart';
 export '../src/notification_config.dart';

--- a/lib/src/default_notification_handler.dart
+++ b/lib/src/default_notification_handler.dart
@@ -134,6 +134,8 @@ class DefaultNotificationHandler extends NotificationWrapper {
 
     if (firebaseOptions != null) {
       // Ensure Firebase is initialized. If called multiple times, it's a no-op.
+      _logger.d('Firebase: ${firebaseOptions.appId}');
+
       if (Firebase.apps.isEmpty) {
         await Firebase.initializeApp(options: firebaseOptions);
         _logger.d('Firebase initialized with provided options.');


### PR DESCRIPTION
- export firebase_core, firebase_analytics, firebase_messaging from flutter_notification_wrapper.dart
- add debug log for Firebase appId inside DefaultNotificationHandler