### PR TITLE
Fix notification popup on Android 33+

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ flutter pub get
 ```gradle
 android {
     compileSdkVersion 34
-    
+
     defaultConfig {
         minSdkVersion 21
         targetSdkVersion 34
@@ -52,11 +52,28 @@ android {
 }
 ```
 
-2. Add notification icons to `android/app/src/main/res/drawable/`:
+2. **Android 13+ (API 33+) Permission Requirement:**
+
+   Add the `POST_NOTIFICATIONS` permission to your `android/app/src/main/AndroidManifest.xml`:
+
+   ```xml
+   <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+       <!-- Required for Android 13+ (API 33+) to show notifications -->
+       <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
+
+       <application ...>
+           <!-- Your application content -->
+       </application>
+   </manifest>
+   ```
+
+   > **Important:** Without this permission declared in the manifest, notifications will not appear on Android 13+ devices even if you request permission at runtime.
+
+3. Add notification icons to `android/app/src/main/res/drawable/`:
    - `notification_icon.png` (for regular notifications)
    - `ic_stat_notification.png` (for status bar)
 
-3. Add Firebase configuration file `google-services.json` to `android/app/`.
+4. Add Firebase configuration file `google-services.json` to `android/app/`.
 
 ### iOS Setup
 
@@ -175,6 +192,52 @@ await DefaultNotificationHandler.initializeSharedInstance(
   },
 );
 ```
+
+## 🏗️ Architecture: FCM vs AwesomeNotifications
+
+This package combines Firebase Cloud Messaging (FCM) and AwesomeNotifications with clear role separation:
+
+| Feature | Firebase Cloud Messaging | AwesomeNotifications |
+|---------|-------------------------|---------------------|
+| **Primary Role** | Receive messages from cloud | Display local notifications |
+| **Message Reception** | ✅ `onMessage`, `onBackgroundMessage` | ❌ |
+| **Notification Display** | Auto-displays (with limitations) | ✅ Full control |
+| **Action Buttons** | ❌ | ✅ |
+| **Scheduling** | ❌ | ✅ |
+| **Reply Input** | ❌ | ✅ |
+| **Badge Management** | ❌ | ✅ |
+
+### Avoiding Duplicate Notifications
+
+On Android < 13, FCM automatically displays notifications when the message contains a `notification` field. This can cause duplicates since this package also uses AwesomeNotifications to display.
+
+**Recommended: Use data-only messages from your server:**
+
+```json
+// ❌ Avoid: Message with notification field (may cause duplicates on Android < 13)
+{
+  "to": "device_token",
+  "notification": {
+    "title": "Hello",
+    "body": "World"
+  },
+  "data": {
+    "key": "value"
+  }
+}
+
+// ✅ Recommended: Data-only message (consistent behavior across all versions)
+{
+  "to": "device_token",
+  "data": {
+    "title": "Hello",
+    "body": "World",
+    "key": "value"
+  }
+}
+```
+
+With data-only messages, this package handles all notification display via AwesomeNotifications, providing consistent behavior across all Android versions including Android 13+.
 
 ## 🎯 Advanced Usage
 

--- a/lib/src/default_notification_handler.dart
+++ b/lib/src/default_notification_handler.dart
@@ -1019,35 +1019,46 @@ class DefaultNotificationHandler extends NotificationWrapper {
     logger.d('Firebase background message processed by instance handler.');
   }
 
-  /// Smart default handler for background messages to avoid duplicates.
+  /// Smart default handler for background messages.
+  ///
+  /// **Important for Android 13+ (API 33+):**
+  /// This handler always uses AwesomeNotifications to display notifications
+  /// because FCM's auto-display behavior is unreliable on Android 13+ due to
+  /// the POST_NOTIFICATIONS runtime permission requirement.
+  ///
+  /// On Android 13+, if the user hasn't granted POST_NOTIFICATIONS permission,
+  /// FCM will silently fail to display notifications. By always using
+  /// AwesomeNotifications, we ensure consistent behavior across all Android versions
+  /// and proper permission handling.
   static Future<void> smartDefaultBackgroundMessageHandler(
     RemoteMessage message,
   ) async {
-    // Use instance logger or a specific static one
     final logger = const Logger(
       'DefaultNotificationHandler',
     )..d(
         '[SmartBackgroundHandler] Processing message: ${message.messageId}, Has Notification Part: ${message.notification != null}',
       );
 
-    // If message.notification is null, it's likely a data-only message,
-    // or FCM isn't auto-displaying. In this case, we show our own.
-    if (message.notification == null) {
-      logger.i(
-        '[SmartBackgroundHandler] Message is data-only or no FCM notification part. Displaying via AwesomeNotifications.',
-      );
-      await DefaultNotificationHandler.I.showNotification(message);
-    } else {
-      logger.i(
-        '[SmartBackgroundHandler] Message has "notification" part. Assuming FCM SDK handles display (Android). Skipping AwesomeNotifications display to avoid duplicates.',
-      );
-      // IMPORTANT: If you have other data processing tasks that need to happen
-      // for background messages (even those with a 'notification' part),
-      // ensure that logic is called here or within a broader data processing function.
-      // For example: await DefaultNotificationHandler.I.processBackgroundMessageData(message.data);
-    }
-    // Example: If you always need to process data regardless of display:
-    // await _processDataFromBackgroundMessage(message.data);
+    // Always display via AwesomeNotifications for consistent behavior across
+    // all Android versions, especially Android 13+ (API 33+) which requires
+    // POST_NOTIFICATIONS permission.
+    //
+    // Previous behavior that caused issues on Android 13+:
+    // - If message had a 'notification' part, we assumed FCM would display it
+    // - On Android 13+, FCM requires POST_NOTIFICATIONS permission to display
+    // - If permission wasn't granted, FCM silently failed and nothing was shown
+    //
+    // Current behavior:
+    // - Always use AwesomeNotifications which has proper permission handling
+    // - This ensures notifications are displayed or the user is properly prompted
+    logger.i(
+      '[SmartBackgroundHandler] Displaying notification via AwesomeNotifications (recommended for Android 13+ compatibility).',
+    );
+    await DefaultNotificationHandler.I.showNotification(message);
+
+    // Note: On Android < 13, this may cause duplicate notifications if FCM
+    // also displays. To prevent duplicates, send data-only messages from your
+    // server (omit the 'notification' field) and let this handler display them.
   }
 }
 


### PR DESCRIPTION
On Android 13+ (API 33+), FCM's auto-display behavior is unreliable because it requires POST_NOTIFICATIONS runtime permission. The previous smartDefaultBackgroundMessageHandler would skip AwesomeNotifications display when messages had a 'notification' part, assuming FCM would handle it. This caused notifications to silently fail on Android 13+.

Changes:
- Modified smartDefaultBackgroundMessageHandler to always use AwesomeNotifications for consistent behavior across all Android versions
- Added POST_NOTIFICATIONS permission requirement to README
- Documented FCM vs AwesomeNotifications architecture and role separation
- Added guidance on using data-only messages to avoid duplicates