### PR TITLE
docs: align all docs with v1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ android {
    > **Important:** Without this permission declared in the manifest, notifications will not appear on Android 13+ devices even if you request permission at runtime.
 
 3. Add notification icons to `android/app/src/main/res/drawable/`:
-   - `notification_icon.png` (for regular notifications)
-   - `ic_stat_notification.png` (for status bar)
+   - `ic_notification.png` (the default icon used by the package)
+   - `ic_stat_notification.png` (optional, for a custom status-bar icon)
 
 4. Add Firebase configuration file `google-services.json` to `android/app/`.
 
@@ -104,7 +104,7 @@ void main() async {
     channelName: 'App Notifications',
     channelDescription: 'General notifications from the app',
     defaultColor: Colors.blue,
-    androidNotificationIcon: 'resource://drawable/notification_icon',
+    androidNotificationIcon: 'resource://drawable/ic_notification',
   );
   
   // Initialize the notification handler.

--- a/analysis/00-RINGKASAN.md
+++ b/analysis/00-RINGKASAN.md
@@ -2,6 +2,13 @@
 
 > Dibuat: 2026-06-19 · Versi yang dianalisa: `0.3.0` · Branch: `main`
 
+> ✅ **SUDAH DITINDAKLANJUTI di v1.0.0** (PR #5, merged 2026-06-19). Dokumen 00–05
+> ini adalah snapshot analisa awal `0.3.0`. Review tajam + plan implementasi ada
+> di [`06-brutal-review.md`](06-brutal-review.md),
+> [`07-review-of-review.md`](07-review-of-review.md), dan
+> [`08-implementation-plan.md`](08-implementation-plan.md) — semuanya sudah
+> diimplementasikan. Lihat juga `1.0.0` di [`../CHANGELOG.md`](../CHANGELOG.md).
+
 Dokumen ini adalah hasil pembacaan menyeluruh seluruh kode package. Tujuannya
 memetakan **apa yang rusak, apa yang bisa dioptimalkan, apa yang perlu di-improve,
 apa yang perlu ditambah, dan apa yang sudah bagus / masih relevan.**

--- a/analysis/06-brutal-review.md
+++ b/analysis/06-brutal-review.md
@@ -1,5 +1,10 @@
 # Brutal Package Review — `flutter_notification_wrapper`
 
+> ✅ **RESOLVED in v1.0.0** (PR #5, merged 2026-06-19). This document is the
+> historical review of `0.3.0`. Every Critical and Major issue below was fixed —
+> see [`08-implementation-plan.md`](08-implementation-plan.md) for the task
+> mapping and the `1.0.0` entry in [`../CHANGELOG.md`](../CHANGELOG.md).
+
 > Reviewer mode: top-tier Pub.dev maintainer / Flutter architect.
 > Version reviewed: `0.3.0` · Branch: `main` · Date: 2026-06-19
 > Standard applied: "Would thousands of production teams choose, trust, and promote this?"

--- a/analysis/07-review-of-review.md
+++ b/analysis/07-review-of-review.md
@@ -1,5 +1,9 @@
 # Review of the Review — Validating `06-brutal-review.md`
 
+> ✅ **RESOLVED in v1.0.0** (PR #5, merged 2026-06-19). Both the confirmed
+> findings and the six additional issues (➕) surfaced here were addressed in the
+> implementation — see [`08-implementation-plan.md`](08-implementation-plan.md).
+
 > Meta-review: every finding in `06-brutal-review.md` re-checked against the
 > actual source (`file:line`). Verdicts: ✅ Confirmed · 🔧 Confirmed + refined ·
 > ⚠️ Overstated · ❌ Wrong · ➕ Missing from the original review.

--- a/analysis/08-implementation-plan.md
+++ b/analysis/08-implementation-plan.md
@@ -8,6 +8,23 @@
 
 ---
 
+## ✅ Status — COMPLETED in v1.0.0 (PR #5, merged 2026-06-19)
+
+All 16 tasks below were implemented, verified, and merged to `main`.
+
+| Phase | Tasks | Status |
+|-------|-------|:------:|
+| 1 — Publish blockers | T1–T5 | ✅ done |
+| 2 — Correctness & resource safety | T6–T9 | ✅ done |
+| 3 — API hygiene & DX | T10–T12 | ✅ done |
+| 4 — Tests, example, infra, docs | T13–T16 | ✅ done |
+
+Verification at merge: `dart format` clean · `flutter analyze` 0 issues ·
+`flutter test` 52 passed · `dart pub publish --dry-run` 0 warnings · CI green.
+The checklists below are kept as the historical plan of record.
+
+---
+
 ## Strategy & sequencing
 
 Four phases. **Phase 1 must ship before any publish.** Phases are mostly

--- a/example/README.md
+++ b/example/README.md
@@ -1,17 +1,51 @@
-# flutter_notification_wrapper_example
+# flutter_notification_wrapper — example
 
-A new Flutter project.
+A runnable demo of [`flutter_notification_wrapper`](../). It exercises the local
+notification features on a single screen:
 
-## Getting Started
+- Request notification permission (contextually, not at startup)
+- Regular notification (returns its id)
+- Action-button notification
+- Reply notification
+- Scheduled notification (+5s)
+- Grouped notifications
+- Badge set / clear
+- Cancel all
 
-This project is a starting point for a Flutter application.
+## Run it
 
-A few resources to get you started if this is your first Flutter project:
+```bash
+cd example
+flutter pub get
+flutter run
+```
 
-- [Learn Flutter](https://docs.flutter.dev/get-started/learn-flutter)
-- [Write your first Flutter app](https://docs.flutter.dev/get-started/codelab)
-- [Flutter learning resources](https://docs.flutter.dev/reference/learning-resources)
+The example runs **without Firebase configured** — every feature above is served
+by AwesomeNotifications alone, so you can try the package in under a minute.
 
-For help getting started with Flutter development, view the
-[online documentation](https://docs.flutter.dev/), which offers tutorials,
-samples, guidance on mobile development, and a full API reference.
+## Enabling Firebase Cloud Messaging (optional)
+
+To receive push messages (foreground / background / terminated):
+
+1. Add `google-services.json` to `android/app/` and
+   `GoogleService-Info.plist` to `ios/Runner/`.
+2. Generate `firebase_options.dart` with the
+   [FlutterFire CLI](https://firebase.google.com/docs/flutter/setup):
+   ```bash
+   flutterfire configure
+   ```
+3. Pass the options in `lib/main.dart`:
+   ```dart
+   await DefaultNotificationHandler.initializeSharedInstance(
+     config: config,
+     firebaseOptions: DefaultFirebaseOptions.currentPlatform,
+   );
+   ```
+
+## Android 13+ note
+
+`POST_NOTIFICATIONS` is already declared in
+`android/app/src/main/AndroidManifest.xml`. Without it, notifications won't show
+on Android 13+ even after the runtime permission is granted.
+
+See the [package README](../README.md) for the full API and configuration guide.


### PR DESCRIPTION
Documentation-only follow-up to PR #5 (the v1.0.0 overhaul).

## Changes
- **README.md** — fix the Android notification icon references to `ic_notification` (the new default branding) in both the setup instructions and the quick-start snippet.
- **example/README.md** — replace the `flutter create` boilerplate ("A new Flutter project") with a real guide: what the demo does, how to run it, optional Firebase setup, and the Android 13+ `POST_NOTIFICATIONS` note.
- **analysis/00, 06, 07, 08** — add "✅ Resolved in v1.0.0" status banners so the review and implementation-plan docs accurately reflect that every issue was implemented and merged (PR #5), instead of reading as still-open.

No code changes; no API/behavior impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)