### PR TITLE
Harden to 1.0.0-beta.1: streams, cold-start, DI seam, topics, rich layout

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ jobs:
     name: Analyze & Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: subosito/flutter-action@v2
         with:
@@ -34,7 +34,7 @@ jobs:
     name: Publish dry-run
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: subosito/flutter-action@v2
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.0.0] - 2026-06-19
+## [1.0.0-beta.1] - 2026-06-20
 
-First production-ready release. This is a correctness and API-hygiene overhaul
-with several **breaking changes**.
+First published release. A correctness and API-hygiene overhaul with several
+**breaking changes**, published as a beta to gather real-world feedback before a
+stable `1.0.0`.
 
 ### Fixed (critical)
 - **Channels now honor `NotificationConfig`.** Channel setup previously hardcoded
@@ -25,9 +26,12 @@ with several **breaking changes**.
 
 ### Changed (breaking)
 - `onFailedToResolveHostname` → **`onError(Object error, StackTrace stackTrace)`**.
-- Display methods now **return the notification id**: `showRegularNotification`,
-  `showActionNotification`, `showReplyNotification`, `scheduleNotification` return
-  `Future<int>`; `showGroupedNotification` returns `Future<List<int>>`.
+- Display methods now **return a nullable id** — `Future<int?>` — returning the
+  id on success and `null` when the platform failed to create the notification,
+  so the return value is an honest success signal you can pass to
+  `cancelNotification`. (`showGroupedNotification` returns the list of ids that
+  were actually created.)
+- **`refreshToken(callback)` removed** in favor of the `onTokenRefresh` stream.
 - `scheduleNotification` now uses **named parameters**:
   `scheduleNotification(id:, title:, body:, scheduledDate:, ...)`.
 - **Permissions are opt-in.** `initialize`/`initializeSharedInstance` no longer
@@ -44,6 +48,16 @@ with several **breaking changes**.
   unused `type.dart` typedefs.
 
 ### Added
+- **Event streams** — `onForegroundMessage`, `onMessageOpened`,
+  `onActionReceived`, `onTokenRefresh` — listen from anywhere (in addition to the
+  constructor overrides).
+- **Cold-start deep links** — `getInitialMessage()` and `getInitialAction()` for
+  taps that launched the app from a terminated state.
+- **FCM topics** — `subscribeToTopic()` / `unsubscribeFromTopic()`.
+- **`showBigPictureNotification()`** rich-layout helper.
+- **Injectable plugin seam** — `AwesomeNotifications` / `FirebaseMessaging` can be
+  injected (via `@visibleForTesting createForTest`), enabling real unit tests of
+  the display/permission/topic logic (mocktail).
 - Deterministic, unique, retrievable notification ids (no more 100s-wrap
   collisions or `messageId.hashCode == 0` overwrites).
 - `permissionStatus` getter + `permissionStatusStream`.
@@ -75,7 +89,7 @@ with several **breaking changes**.
 + import 'package:flutter_notification_wrapper/utils.dart';
 ```
 
-## [0.3.0] - 2024-01-XX
+## [0.3.0] - unreleased
 
 ### Added
 - **Enhanced NotificationConfig**: Added comprehensive configuration options including importance levels, vibration, LED lights, and privacy settings
@@ -105,7 +119,7 @@ with several **breaking changes**.
 - **Version Bump**: Updated to version 0.3.0 with improved dependency versions
 - **Documentation**: Complete rewrite of README with comprehensive examples and setup instructions
 
-## [0.2.0] - 2024-01-XX
+## [0.2.0] - unreleased
 
 ### Added
 - Initial implementation of NotificationWrapper abstract class
@@ -125,7 +139,7 @@ with several **breaking changes**.
 - Permission handling
 - Debug and simulation tools
 
-## [0.1.0] - 2024-01-XX
+## [0.1.0] - unreleased
 
 ### Added
 - Initial project setup

--- a/README.md
+++ b/README.md
@@ -3,22 +3,25 @@
 [![pub package](https://img.shields.io/pub/v/flutter_notification_wrapper.svg)](https://pub.dev/packages/flutter_notification_wrapper)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-A comprehensive Flutter package that provides a unified interface for Firebase Cloud Messaging and AwesomeNotifications with advanced features like background handling, action buttons, scheduling, and more.
+A Flutter package that provides a unified interface for Firebase Cloud Messaging and AwesomeNotifications with background handling, action buttons, scheduling, grouping, and badge management.
+
+> **Status:** `1.0.0-beta.1` — published for real-world feedback. The API is close
+> to stable but may still change before `1.0.0`. Supports **Android & iOS** only.
 
 ## 🚀 Features
 
-- **Unified Interface**: Single API for both Firebase Cloud Messaging and AwesomeNotifications
-- **Cross-Platform**: Full support for Android and iOS
-- **Background Processing**: Handle notifications in foreground, background, and terminated states
-- **Interactive Notifications**: Support for action buttons, reply notifications, and custom interactions
-- **Advanced Scheduling**: Schedule notifications for future delivery
-- **Notification Grouping**: Group related notifications together
-- **Badge Management**: Update and clear app badge counts
-- **Customizable Channels**: Multiple notification channels with different priorities and behaviors
-- **Debug Tools**: Built-in simulation and debugging capabilities
-- **Type Safety**: Full Dart type safety with comprehensive error handling
-- **Reactive State**: Built-in reactive programming utilities
-- **Comprehensive Logging**: Configurable logging system for debugging
+- **Unified Interface**: Single API over Firebase Cloud Messaging (delivery) and AwesomeNotifications (display)
+- **Background & Terminated Handling**: Foreground, background, and terminated-state messages
+- **Cold-start Deep Links**: `getInitialMessage()` / `getInitialAction()` for taps that launched the app
+- **Streams & Callbacks**: Listen via streams (`onActionReceived`, `onMessageOpened`, …) or constructor overrides
+- **Interactive Notifications**: Action buttons and reply notifications
+- **Scheduling**: Schedule notifications for future delivery
+- **Notification Grouping** and **Badge Management**
+- **FCM Topics**: `subscribeToTopic` / `unsubscribeFromTopic`
+- **Customizable Channels**: Priorities, sound, vibration, privacy via `NotificationConfig`
+
+> A small set of optional helpers (`Logger`, `Rx`, `Debouncer`) used internally is
+> available via a separate `package:flutter_notification_wrapper/utils.dart` import.
 
 ## 📦 Installation
 
@@ -328,11 +331,49 @@ if (status == AuthorizationStatus.authorized) {
 final token = await handler.getFcmToken();
 print('FCM Token: $token');
 
-// Listen for token refresh
-await handler.refreshToken((newToken) {
+// Listen for token refresh (stream)
+handler.onTokenRefresh.listen((newToken) {
   print('Token refreshed: $newToken');
   // Send token to your server
 });
+
+// Topics
+await handler.subscribeToTopic('news');
+await handler.unsubscribeFromTopic('news');
+```
+
+### Listening to events (streams)
+
+Prefer streams when you need to react from more than one place in the app:
+
+```dart
+final handler = DefaultNotificationHandler.I;
+
+handler.onForegroundMessage.listen((message) { /* FCM in foreground */ });
+handler.onMessageOpened.listen((message)    { /* FCM tapped (from background) */ });
+handler.onActionReceived.listen((action)    { /* notification / button tapped */ });
+```
+
+### Cold-start deep links
+
+When the app is launched from a **terminated** state by tapping a notification,
+read the initial message/action once after `initialize`:
+
+```dart
+final message = await handler.getInitialMessage();   // RemoteMessage? (FCM)
+final action  = await handler.getInitialAction();    // ReceivedAction? (local)
+if (message != null) navigateFromData(message.data);
+if (action != null)  navigateFromPayload(action.payload);
+```
+
+### Rich (big-picture) notifications
+
+```dart
+await handler.showBigPictureNotification(
+  title: 'New photo',
+  body: 'Tap to view',
+  bigPicture: 'https://example.com/image.jpg', // or asset://, resource://, file://
+);
 ```
 
 ## 🧪 Testing and Debugging
@@ -456,6 +497,16 @@ await DefaultNotificationHandler.initializeSharedInstance(
 | `defaultPrivacy`           | `NotificationPrivacy`     | Privacy level                     | `Public`    |
 | `wakeUpScreen`             | `bool`                    | Wake/turn on screen on display    | `false`     |
 | `category`                 | `NotificationCategory?`   | Default notification category     | `null`      |
+
+## ✅ Verification & Known Limitations
+
+- Unit tests cover config→channel mapping, id generation, and the real handler
+  logic (via an injected, mockable `AwesomeNotifications`/`FirebaseMessaging`).
+- An example smoke integration test proves the end-to-end path on a device.
+- **Terminated-state FCM delivery** is verified manually (it needs a real device
+  + a push server). See [`VERIFICATION.md`](VERIFICATION.md) for the procedure.
+- **Limitations:** Android & iOS only; a single process-wide handler instance
+  (`DefaultNotificationHandler.I`).
 
 ## 🤝 Contributing
 

--- a/VERIFICATION.md
+++ b/VERIFICATION.md
@@ -1,0 +1,50 @@
+# Verification
+
+How the package's behavior is verified, and how to reproduce the parts that
+cannot be automated.
+
+## Automated
+
+- **Unit tests** (`flutter test`) — config→channel mapping, deterministic id
+  generation, the singleton fallback, `Rx.listenWithPrevious`, and the real
+  handler logic via an injected `AwesomeNotifications`/`FirebaseMessaging`
+  (mocktail): `show*` create on the configured channel, `show*` return `null` and
+  report `onError` on platform failure, channel setup reflects `NotificationConfig`,
+  and topic/cold-start delegation.
+- **Example smoke integration test** (`cd example && flutter test integration_test`)
+  — drives the example on a device/emulator and proves the full
+  init → channel-setup → `createNotification` path runs without crashing.
+
+## Manual — terminated-state FCM (cannot be automated without a push server)
+
+Displaying an FCM message while the app is **terminated** depends on the OS, a
+real device, and a push from a server, so it is verified manually:
+
+1. Configure Firebase in the example (`google-services.json` / FlutterFire) and
+   set `firebaseOptions:` in `example/lib/main.dart`.
+2. Build a **release** (or profile) build and install on a physical Android 13+
+   device: `cd example && flutter run --release`.
+3. Grant the notification permission, then fully **swipe the app away** (terminate).
+4. Send a **data-only** message to the device token (omit the `notification`
+   field) via FCM HTTP v1 / the Firebase console test tool:
+   ```json
+   { "message": { "token": "<DEVICE_TOKEN>",
+       "data": { "title": "Hello", "body": "From a terminated state" } } }
+   ```
+5. **Expect:** a notification appears even though the app was terminated
+   (AwesomeNotifications is initialized on-demand in the background isolate).
+6. Tap it; on launch, `getInitialMessage()` / `getInitialAction()` returns the
+   payload so the app can deep-link.
+
+Repeat on Android < 13 with a data-only message to confirm there is no duplicate
+(see the "Avoiding Duplicate Notifications" section in the README).
+
+## Known limitations
+
+- **Platforms:** Android & iOS only (AwesomeNotifications is mobile-only). No
+  web/desktop.
+- **Single shared instance:** the handler is a process-wide singleton
+  (`DefaultNotificationHandler.I`); running multiple independent configurations
+  is not supported.
+- **Terminated-state delivery** is environment-dependent (OEM battery policies,
+  permission state) and is only validated via the manual procedure above.

--- a/analysis/09-gatekeeper-review.md
+++ b/analysis/09-gatekeeper-review.md
@@ -1,0 +1,237 @@
+# Gatekeeper Review — `flutter_notification_wrapper@1.0.0`
+
+> Strict "does this deserve to be on Pub.dev" audit of the **current `main`
+> (v1.0.0)**, after the overhaul in PR #5. Date: 2026-06-20.
+> Companion to [`06-brutal-review.md`](06-brutal-review.md) (review of `0.3.0`)
+> and [`08-implementation-plan.md`](08-implementation-plan.md) (the overhaul).
+
+---
+
+## Core question
+
+**"Would you personally feel comfortable recommending this package to the
+Flutter community?"**
+
+**Not as a *recommendation* — yet. But it is now *safe to publish*.** The v1.0.0
+overhaul removed the things that made the old version embarrassing (placeholder
+license, inert config, AI transcript in source, crash-on-error, leaks). What
+remains is a *competent but unremarkable* wrapper: global-singleton design, a
+leaky "unified" abstraction, near-zero tests on the risky code, and thin
+differentiation versus incumbents. Publishable — not yet respected-package
+material.
+
+**Verdict: B — PUBLISH AFTER MINOR CHANGES** (and as `0.x`/`1.0.0-beta`, not a
+bare `1.0.0`).
+
+---
+
+## Missing features (expected, not found)
+
+1. **Stream-based event API.** Everything goes through constructor callbacks
+   (`onMessageOverride`, `handleActionReceivedOverride`). Idiomatic packages
+   expose `Stream`s consumable anywhere. Forcing all handlers into one init call
+   means you can't react to a tap from a screen built later. **#1 DX gap.**
+2. **No `getInitialMessage()` / `getInitialAction()`** cold-start retrieval —
+   the canonical "deep-link from a terminated notification tap" need. Conspicuous
+   for a package whose headline is background/terminated handling.
+3. **`refreshToken(callback)` instead of `Stream<String> get onTokenRefresh`** —
+   non-idiomatic, single-listener.
+4. **No FCM topic subscription** (`subscribeToTopic` / `unsubscribeFromTopic`).
+5. **No exposed rich layouts (media/big-picture/progress)** through the unified
+   API — you drop to raw `NotificationContent`, defeating "unified".
+6. **No web/desktop** (awesome_notifications is mobile-only) — yet README says
+   "Cross-Platform".
+
+---
+
+## Missing / weak documentation
+
+1. **`pubspec.yaml: documentation:` points to a GitHub wiki** that almost
+   certainly doesn't exist → broken link → pub.dev score hit + bad first
+   impression.
+2. **`CHANGELOG.md` placeholder dates** `2024-01-XX` for 0.1.0/0.2.0/0.3.0.
+3. **README overclaims** — lists "Debug Tools" and "Reactive State" as headline
+   features of a notifications package; "comprehensive"/"Full support".
+4. **No terminated-state deep-link recipe**, no `dispose()` lifecycle guidance
+   for the global singleton, no note that custom background handlers must be
+   top-level `@pragma('vm:entry-point')`.
+5. **README on `main` still references `notification_icon`** while the code
+   default is `ic_notification` (fixed in unmerged PR #6).
+
+---
+
+## API problems
+
+- **Global singleton `DefaultNotificationHandler.I`** — global mutable state;
+  can't run two configs; hostile to testing (no injection); the on-the-fly
+  `get I` fallback silently fabricates an instance, hiding misconfiguration.
+- **`show*` returns an `int` id even on failure** — caught error → `onError` →
+  `return id`. Caller gets an id for a notification that may not exist;
+  `cancelNotification(id)` becomes a silent no-op. Return value is not a reliable
+  success signal. Prefer `Future<int?>` (null on failure) or rethrow.
+- **`requestPermissions()` returns only the FCM `AuthorizationStatus`** while
+  also requesting AwesomeNotifications permission separately; the two can
+  disagree and the return type can't express it.
+- **`simulateNotification` is redundant** with `showRegularNotification`.
+- **Abstraction leaks both SDKs** — `showGroupedNotification(List<NotificationContent>)`,
+  `ReceivedAction`, `RemoteMessage`. The "unified interface" still requires
+  fluency in both libraries; re-exporting their types hard-couples your public
+  API to their versioning.
+- **`NotificationConfig.custom()`** duplicates the default constructor verbatim.
+
+---
+
+## Architecture problems
+
+- **Tight coupling to two fast-moving upstreams you re-export** — their breaking
+  changes become yours, and consumers feel them directly.
+- **No dependency-injection seam** — `AwesomeNotifications()` /
+  `FirebaseMessaging.instance` are concrete singletons throughout. This is why
+  your own tests can't cover real logic and consumers can't unit-test against
+  the package. **Biggest architectural weakness.**
+- **Abstract `NotificationWrapper` reaches into concrete `DefaultNotificationHandler.I`**
+  (default background handler) — abstraction depends on implementation.
+- **Bundled mini-framework** (`Rx`, `RxBool`, `RxList`, `Debouncer`, `Logger`) —
+  scope creep you must maintain forever; respected packages do one thing.
+
+---
+
+## Performance / production risks
+
+- Resource lifecycle is now **correct** (subscriptions cancelled, single refresh
+  listener, Rx disposed). Remaining awkwardness: `dispose()` ownership on a
+  global singleton across hot restarts / `ReceivePort` name mapping.
+- **ID generator resets per process** (`_lastGeneratedId → 0`); reseeded from
+  wall-clock, so cross-session collision is unlikely but not impossible.
+- **`_stableId = String.hashCode & 0x7FFFFFFF`** — two distinct `messageId`s can
+  collide over 31 bits → one notification overwrites another. Rare; ugly when it
+  happens in chat/payments.
+- **`_permissionRequestLock` is a plain `bool`**, not await-safe.
+- **Biggest production risk: the terminated-state path is unverified.** The fix
+  is plausible but there is **no integration test and no device proof** that a
+  cold-start FCM message actually displays — the package's entire raison d'être.
+
+---
+
+## Testing — the honest gap
+
+`flutter test` → **52 green**, but coverage is misleading: tests cover
+`NotificationConfig`→channel mapping, id-generator uniqueness, the singleton
+fallback, and `Rx`/`Debouncer`/`Logger`. **Zero tests touch the real flow**
+(FCM→display, channel creation, permission flow, action routing, background
+isolate) because the platform singletons aren't injectable. The riskiest ~80% of
+the package has no automated verification.
+
+---
+
+## Community adoption risks
+
+- **Avoid:** adds a dependency + a second display engine + Firebase to save ~an
+  afternoon of wiring devs would rather own.
+- **Uninstall:** first upstream breaking change blocks them on your compat
+  release; or a terminated-state notification silently fails and they can't
+  debug through the abstraction.
+- **Maintainers won't recommend:** global singleton, no DI/testability, leaky
+  abstraction, 1.0.0 with no track record.
+- **Teams reject:** can't unit-test against it; pulls Firebase + awesome
+  transitively; "1.0.0" overpromises.
+
+---
+
+## Competitor analysis
+
+- **`flutter_local_notifications`** — de-facto standard; Android/iOS/Linux/macOS;
+  years of hardening; rich layouts; `getNotificationAppLaunchDetails()`. **Yours
+  is worse** on breadth, maturity, testability, trust; *arguably better* only via
+  its opinionated FCM + always-local-display-on-Android-13 default.
+- **`firebase_messaging`** (official) — you wrap it, don't beat it.
+- **`awesome_notifications`** — you wrap and re-export it; inherit its surface
+  without hiding it.
+- **Real niche:** FCM + local-display + Android-13 permission/display glue that
+  devs hand-wire today. Real but narrow; your value-add is convenience, not
+  capability. Devs switch only if the wrapper is rock-solid — not proven yet.
+
+---
+
+## DO NOT PUBLISH YET (blockers, by severity)
+
+| # | Severity | Issue | Impact | Fix |
+|---|----------|-------|--------|-----|
+| 1 | **High** | `documentation:` → non-existent wiki | Broken link, pub.dev score hit | Create wiki or remove field |
+| 2 | **High** | README (main) stale `notification_icon` + overclaims "Debug Tools/Reactive State" | Misleads users; icon mismatch breaks setup | Merge PR #6; trim feature list |
+| 3 | **Medium** | CHANGELOG `2024-01-XX` placeholder dates | Reads as careless | Real dates or collapse pre-1.0 history |
+| 4 | **Medium** | No `getInitialMessage()/getInitialAction()` cold-start retrieval | Can't deep-link from terminated tap | Add, or document omission loudly |
+| 5 | **Medium** | `show*` returns id even on failure | Silent cancel no-ops; dishonest return | `Future<int?>` or rethrow |
+| 6 | **Medium** | Terminated-state path unverified | Headline reliability unproven | Integration test or documented manual verification + known-limitations note |
+| 7 | **Low** | Global singleton, no DI seam | Limits consumer testability | Document now; injectable instance in 1.x |
+| 8 | **Low** | CI `actions/checkout@v4` (Node 20 deprecation) | Warning noise | Bump to `@v5` |
+
+None are "broken/dangerous" — they're "don't put your name on it until fixed".
+#1–#3 + #8 are ~an hour; #4–#6 are the gap between *publishable* and
+*recommendable*.
+
+---
+
+## Recommended action plan (ordered)
+
+**Phase A — cheap publish-cleanup (do first, ~1h):**
+- A1. Remove or fix `pubspec.yaml: documentation:` (drop the wiki link).
+- A2. Merge PR #6 (README icon/branding + example README) and trim the README
+  feature list to the core (move "reactive utilities" to a one-line "extras").
+- A3. Fix CHANGELOG placeholder dates.
+- A4. Bump CI `actions/checkout@v4` → `@v5`.
+- A5. **Re-version to `1.0.0-beta.1`** (or `0.9.0`) — a fresh, untested-in-the-wild
+  rewrite should not claim bare `1.0.0` stability.
+
+**Phase B — earn "recommendable" (before a stable 1.0.0):**
+- B1. Add `getInitialMessage()` / `getInitialAction()` for cold-start deep links.
+- B2. Add stream getters: `Stream<RemoteMessage> get onMessageOpened`,
+  `Stream<ReceivedAction> get onActionReceived`, `Stream<String> get onTokenRefresh`.
+- B3. Make `show*` honest: `Future<int?>` (null on failure) or rethrow.
+- B4. Add an injection seam (constructor-injectable `AwesomeNotifications` /
+  `FirebaseMessaging`) so the core flow becomes testable; add real handler tests.
+- B5. Add one integration test (or a documented, repeatable manual procedure)
+  proving terminated-state display on Android 13+.
+- B6. Decide the fate of the bundled `Rx`/`Debouncer` utilities (keep minimal,
+  or split out) to narrow scope.
+
+**Phase C — optional differentiation:**
+- C1. `subscribeToTopic` / `unsubscribeFromTopic`.
+- C2. Richer unified layout helpers (big-picture / media / progress).
+
+---
+
+## Final decision: Verdict B — PUBLISH AFTER MINOR CHANGES
+
+The hard blockers are gone — licensed, config works, resources clean, errors
+don't crash, example runs, CI green, dry-run 0 warnings. But it is not
+presentable until Phase A lands, and not *recommendable* until Phase B. Ship
+Phase A as **`1.0.0-beta.1`**, gather real-world mileage, then graduate to a
+stable `1.0.0` after Phase B.
+
+---
+
+## Confidence check
+
+1. **Recommend if published tomorrow?** No — only "works for the FCM+local glue
+   niche; evaluate vs wiring it yourself."
+2. **Use in my own production app?** No — I'd use `firebase_messaging` +
+   `flutter_local_notifications` directly, unless I specifically wanted the
+   Android-13 always-local-display default.
+3. **Let my team depend on it?** Not at 1.0.0 with no integration tests + global
+   singleton. Maybe after hardening.
+4. **Experienced devs respect it?** Neutral-to-mild. They'd respect the cleanup
+   and honest migration notes; be skeptical of the singleton, leaky abstraction,
+   thin tests.
+5. **Solves a real problem better than alternatives?** More *conveniently* for a
+   narrow glue case; not *better* in capability, breadth, or trust.
+6. **Potential to become recommended?** Yes — if Phase B lands and it survives a
+   couple of upstream breaking-change cycles cleanly.
+7. **Biggest reason it could fail:** thin wrapper over two fast-moving SDKs with
+   no testability seam and unproven terminated-state reliability — upside
+   (saved boilerplate) < downside (inherited breakage + undebuggable abstraction)
+   for serious teams.
+8. **Biggest reason it could succeed:** it nails a genuinely annoying, commonly
+   re-wired integration (FCM + AwesomeNotifications + Android-13 consistency)
+   behind one opinionated default — if proven reliable, that convenience is worth
+   a dependency to many small/mid teams.

--- a/analysis/09-gatekeeper-review.md
+++ b/analysis/09-gatekeeper-review.md
@@ -1,5 +1,13 @@
 # Gatekeeper Review — `flutter_notification_wrapper@1.0.0`
 
+> ✅ **ADDRESSED in `1.0.0-beta.1`.** All blockers (#1–#8) plus Phase A/B/C of the
+> action plan were implemented: wiki link removed, README/CHANGELOG fixed,
+> re-versioned to beta, `getInitialMessage()/getInitialAction()`, event streams,
+> `Future<int?>` show methods, an injectable plugin seam + real handler tests,
+> FCM topics, big-picture helper, and a terminated-state verification procedure
+> ([`../VERIFICATION.md`](../VERIFICATION.md)). This document is retained as the
+> pre-hardening assessment.
+
 > Strict "does this deserve to be on Pub.dev" audit of the **current `main`
 > (v1.0.0)**, after the overhaul in PR #5. Date: 2026-06-20.
 > Companion to [`06-brutal-review.md`](06-brutal-review.md) (review of `0.3.0`)

--- a/example/integration_test/app_test.dart
+++ b/example/integration_test/app_test.dart
@@ -1,0 +1,31 @@
+// End-to-end smoke test for the example app.
+//
+// Run on a device/emulator (it touches real platform channels):
+//   cd example && flutter test integration_test
+//
+// It proves the full call path (init → channel setup → createNotification)
+// runs without crashing on a real device. It does NOT (and cannot, without a
+// push server) assert terminated-state FCM delivery — see VERIFICATION.md for
+// the manual procedure for that case.
+import 'package:flutter_notification_wrapper_example/main.dart' as app;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('shows a local notification end-to-end', (tester) async {
+    await app.main();
+    await tester.pumpAndSettle();
+
+    expect(find.text('Show regular'), findsOneWidget);
+
+    await tester.tap(find.text('Show regular'));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.textContaining('Shown regular notification id='),
+      findsOneWidget,
+    );
+  });
+}

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -37,6 +37,17 @@ Future<void> main() async {
     },
   );
 
+  // Cold-start deep links: read whatever launched the app from a terminated
+  // state (null in the common case).
+  final initialMessage = await DefaultNotificationHandler.I.getInitialMessage();
+  if (initialMessage != null) {
+    debugPrint('Launched from FCM message: ${initialMessage.data}');
+  }
+  final initialAction = await DefaultNotificationHandler.I.getInitialAction();
+  if (initialAction != null) {
+    debugPrint('Launched from notification action: ${initialAction.payload}');
+  }
+
   runApp(const ExampleApp());
 }
 

--- a/example/lib/screens/home_screen.dart
+++ b/example/lib/screens/home_screen.dart
@@ -66,6 +66,20 @@ class _HomeScreenState extends State<HomeScreen> {
     _report('Scheduled notification id=$id for $when');
   }
 
+  Future<void> _showBigPicture() async {
+    final id = await _handler.showBigPictureNotification(
+      title: 'New photo',
+      body: 'Tap to view',
+      bigPicture: 'https://picsum.photos/600/300',
+    );
+    _report('Shown big-picture notification id=$id');
+  }
+
+  Future<void> _subscribeTopic() async {
+    await _handler.subscribeToTopic('news');
+    _report('Subscribed to topic "news"');
+  }
+
   Future<void> _showGrouped() async {
     final ids = await _handler.showGroupedNotification('chat_messages', [
       NotificationContent(
@@ -109,7 +123,9 @@ class _HomeScreenState extends State<HomeScreen> {
       ('Show action buttons', _showAction),
       ('Show reply', _showReply),
       ('Schedule (+5s)', _schedule),
+      ('Show big picture', _showBigPicture),
       ('Show grouped', _showGrouped),
+      ('Subscribe to "news" topic', _subscribeTopic),
       ('Set badge = 5', _setBadge),
       ('Clear badge', _clearBadge),
       ('Cancel all', _cancelAll),

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -73,6 +73,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.3"
+  file:
+    dependency: transitive
+    description:
+      name: file
+      sha256: a3b4f84adafef897088c160faf7dfffb7696046cb13ae90b508c2cbc95d3b8d4
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.1"
   firebase_core:
     dependency: transitive
     description:
@@ -126,6 +134,11 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_driver:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -140,7 +153,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.0.0"
+    version: "1.0.0-beta.1"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -148,6 +161,16 @@ packages:
     version: "0.0.0"
   flutter_web_plugins:
     dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
+  fuchsia_remote_debug_protocol:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
+  integration_test:
+    dependency: "direct dev"
     description: flutter
     source: sdk
     version: "0.0.0"
@@ -223,6 +246,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  platform:
+    dependency: transitive
+    description:
+      name: platform
+      sha256: "5d6b1b0036a5f331ebc77c850ebc8506cbc1e9416c27e59b439f917a902a4984"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.6"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -231,6 +262,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.8"
+  process:
+    dependency: transitive
+    description:
+      name: process
+      sha256: c6248e4526673988586e8c00bb22a49210c258dc91df5227d5da9748ecf79744
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.5"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -268,6 +307,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.1"
+  sync_http:
+    dependency: transitive
+    description:
+      name: sync_http
+      sha256: "7f0cd72eca000d2e026bcd6f990b81d0ca06022ef4e32fb257b30d3d1014a961"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.1"
   term_glyph:
     dependency: transitive
     description:
@@ -308,6 +355,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
+  webdriver:
+    dependency: transitive
+    description:
+      name: webdriver
+      sha256: "2f3a14ca026957870cfd9c635b83507e0e51d8091568e90129fbf805aba7cade"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.0"
 sdks:
   dart: ">=3.10.0-0 <4.0.0"
   flutter: ">=3.22.0"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -16,6 +16,8 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  integration_test:
+    sdk: flutter
   flutter_lints: ^4.0.0
 
 flutter:

--- a/lib/src/default_notification_handler.dart
+++ b/lib/src/default_notification_handler.dart
@@ -22,6 +22,8 @@ import 'utils/rx.dart';
 /// handler via [DefaultNotificationHandler.I].
 class DefaultNotificationHandler extends NotificationWrapper {
   DefaultNotificationHandler._internal({
+    AwesomeNotifications? awesomeNotifications,
+    FirebaseMessaging? firebaseMessaging,
     super.onMessageOverride,
     super.onMessageOpenedAppOverride,
     super.onBackgroundMessageOverride,
@@ -31,9 +33,18 @@ class DefaultNotificationHandler extends NotificationWrapper {
     super.handleActionReceivedOverride,
     super.onError,
     super.onPermissionEvent,
-  });
+  })  : _awesomeOverride = awesomeNotifications,
+        _messagingOverride = firebaseMessaging;
 
   static const Logger _logger = Logger('DefaultNotificationHandler');
+
+  // --- Injectable plugin seams (default to the real singletons) ---
+  final AwesomeNotifications? _awesomeOverride;
+  final FirebaseMessaging? _messagingOverride;
+  AwesomeNotifications get _awesome =>
+      _awesomeOverride ?? AwesomeNotifications();
+  FirebaseMessaging get _messaging =>
+      _messagingOverride ?? FirebaseMessaging.instance;
 
   final Debouncer _notificationDebouncer =
       Debouncer(delay: const Duration(milliseconds: 500));
@@ -49,13 +60,32 @@ class DefaultNotificationHandler extends NotificationWrapper {
   Stream<AuthorizationStatus> get permissionStatusStream =>
       _permissionStatus.stream;
 
+  // --- Event streams (broadcast) ---
+  final StreamController<RemoteMessage> _foregroundMessageController =
+      StreamController<RemoteMessage>.broadcast();
+  final StreamController<RemoteMessage> _messageOpenedController =
+      StreamController<RemoteMessage>.broadcast();
+  final StreamController<ReceivedAction> _actionController =
+      StreamController<ReceivedAction>.broadcast();
+  final StreamController<String> _tokenRefreshController =
+      StreamController<String>.broadcast();
+
+  @override
+  Stream<RemoteMessage> get onForegroundMessage =>
+      _foregroundMessageController.stream;
+  @override
+  Stream<RemoteMessage> get onMessageOpened => _messageOpenedController.stream;
+  @override
+  Stream<ReceivedAction> get onActionReceived => _actionController.stream;
+  @override
+  Stream<String> get onTokenRefresh => _tokenRefreshController.stream;
+
   bool _permissionRequestLock = false;
   NotificationConfig? _config;
 
   // Active stream subscriptions, cancelled on [dispose] / re-init.
   final List<StreamSubscription<dynamic>> _subscriptions =
       <StreamSubscription<dynamic>>[];
-  StreamSubscription<String>? _tokenRefreshSub;
 
   static ReceivePort? _receivePort;
   static const String _portName = 'notification_action_port';
@@ -111,6 +141,25 @@ class DefaultNotificationHandler extends NotificationWrapper {
   /// Exposes the internal stable-id derivation for tests.
   @visibleForTesting
   static int debugStableId(String? key) => _stableId(key);
+
+  /// Creates an instance wired to injected plugins and registers it as the
+  /// shared singleton, *without* running [initialize]. Test-only.
+  @visibleForTesting
+  static DefaultNotificationHandler createForTest({
+    required AwesomeNotifications awesomeNotifications,
+    FirebaseMessaging? firebaseMessaging,
+    NotificationConfig? config,
+    void Function(Object error, StackTrace stackTrace)? onError,
+  }) {
+    final handler = DefaultNotificationHandler._internal(
+      awesomeNotifications: awesomeNotifications,
+      firebaseMessaging: firebaseMessaging,
+      onError: onError,
+    );
+    handler._config = config ?? NotificationConfig.defaultConfig();
+    _instance = handler;
+    return handler;
+  }
 
   /// Resets the singleton. Test-only.
   @visibleForTesting
@@ -187,12 +236,23 @@ class DefaultNotificationHandler extends NotificationWrapper {
         FirebaseMessaging.onMessage.listen((message) {
           _logger.d('FCM onMessage: ${message.messageId}');
           onMessage(message);
+          if (!_foregroundMessageController.isClosed) {
+            _foregroundMessageController.add(message);
+          }
         }),
       );
       _subscriptions.add(
         FirebaseMessaging.onMessageOpenedApp.listen((message) {
           _logger.d('FCM onMessageOpenedApp: ${message.messageId}');
-          _debounceHandleNotification(message, onMessageOpenedApp);
+          _debounceHandleNotification(message, _handleMessageOpened);
+        }),
+      );
+      _subscriptions.add(
+        _messaging.onTokenRefresh.listen((token) {
+          _logger.i('FCM Token refreshed: $token');
+          if (!_tokenRefreshController.isClosed) {
+            _tokenRefreshController.add(token);
+          }
         }),
       );
     } else {
@@ -208,13 +268,18 @@ class DefaultNotificationHandler extends NotificationWrapper {
     _logger.d('DefaultNotificationHandler initialized.');
   }
 
+  void _handleMessageOpened(RemoteMessage message) {
+    onMessageOpenedApp(message);
+    if (!_messageOpenedController.isClosed) {
+      _messageOpenedController.add(message);
+    }
+  }
+
   Future<void> _clearSubscriptions() async {
     for (final sub in _subscriptions) {
       await sub.cancel();
     }
     _subscriptions.clear();
-    await _tokenRefreshSub?.cancel();
-    _tokenRefreshSub = null;
   }
 
   Future<void> _setupNotificationChannels() async {
@@ -251,7 +316,7 @@ class DefaultNotificationHandler extends NotificationWrapper {
       for (final channel in channels) channel.channelKey!: channel,
     };
 
-    await AwesomeNotifications().initialize(
+    await _awesome.initialize(
       config.androidNotificationIcon,
       unique.values.toList(),
       debug: kDebugMode,
@@ -310,12 +375,36 @@ class DefaultNotificationHandler extends NotificationWrapper {
     return key.hashCode & 0x7FFFFFFF;
   }
 
-  // ================== FCM ===================
+  // ================== COLD-START / DEEP LINK ===================
+
+  @override
+  Future<RemoteMessage?> getInitialMessage() async {
+    try {
+      return await _messaging.getInitialMessage();
+    } catch (e, st) {
+      _logger.e('Error reading initial FCM message: $e');
+      onError?.call(e, st);
+      return null;
+    }
+  }
+
+  @override
+  Future<ReceivedAction?> getInitialAction() async {
+    try {
+      return await _awesome.getInitialNotificationAction();
+    } catch (e, st) {
+      _logger.e('Error reading initial notification action: $e');
+      onError?.call(e, st);
+      return null;
+    }
+  }
+
+  // ================== FCM TOKEN & TOPICS ===================
 
   @override
   Future<String?> getFcmToken() async {
     try {
-      final token = await FirebaseMessaging.instance.getToken();
+      final token = await _messaging.getToken();
       _logger.d('FCM Token: $token');
       return token;
     } catch (e, st) {
@@ -326,19 +415,31 @@ class DefaultNotificationHandler extends NotificationWrapper {
   }
 
   @override
-  Future<void> refreshToken(void Function(String) onTokenRefresh) async {
-    await _tokenRefreshSub?.cancel();
-    _tokenRefreshSub =
-        FirebaseMessaging.instance.onTokenRefresh.listen((token) {
-      _logger.i('FCM Token refreshed: $token');
-      onTokenRefresh(token);
-    });
+  Future<void> subscribeToTopic(String topic) async {
+    try {
+      await _messaging.subscribeToTopic(topic);
+      _logger.d('Subscribed to topic: $topic');
+    } catch (e, st) {
+      _logger.e('Error subscribing to topic "$topic": $e');
+      onError?.call(e, st);
+    }
+  }
+
+  @override
+  Future<void> unsubscribeFromTopic(String topic) async {
+    try {
+      await _messaging.unsubscribeFromTopic(topic);
+      _logger.d('Unsubscribed from topic: $topic');
+    } catch (e, st) {
+      _logger.e('Error unsubscribing from topic "$topic": $e');
+      onError?.call(e, st);
+    }
   }
 
   // ================== DISPLAY ===================
 
   @override
-  Future<int> showNotification(RemoteMessage message) async {
+  Future<int?> showNotification(RemoteMessage message) async {
     await _ensureChannelsInitialized();
     final config = _config ??= NotificationConfig.defaultConfig();
     final id = _stableId(message.messageId);
@@ -348,7 +449,7 @@ class DefaultNotificationHandler extends NotificationWrapper {
         message.data['body'] ??
         'You have a new message.';
     try {
-      await AwesomeNotifications().createNotification(
+      await _awesome.createNotification(
         content: NotificationContent(
           id: id,
           channelKey: config.channelKey,
@@ -362,18 +463,19 @@ class DefaultNotificationHandler extends NotificationWrapper {
         ),
       );
       _logger.d('Local notification created for FCM: ${message.messageId}');
+      return id;
     } catch (e, st) {
       _logger.e('Error showing notification from FCM: $e');
       onError?.call(e, st);
+      return null;
     }
-    return id;
   }
 
   Map<String, String?> _convertPayload(Map<String, dynamic> data) =>
       data.map((key, value) => MapEntry(key, value?.toString()));
 
   @override
-  Future<int> showRegularNotification({
+  Future<int?> showRegularNotification({
     required String title,
     required String body,
     Map<String, String>? payload,
@@ -384,7 +486,7 @@ class DefaultNotificationHandler extends NotificationWrapper {
     final id = _generateId();
     _logger.d('Showing regular notification: "$title"');
     try {
-      await AwesomeNotifications().createNotification(
+      await _awesome.createNotification(
         content: NotificationContent(
           id: id,
           channelKey: channelKey ?? config.channelKey,
@@ -396,15 +498,16 @@ class DefaultNotificationHandler extends NotificationWrapper {
           category: config.category,
         ),
       );
+      return id;
     } catch (e, st) {
       _logger.e('Error showing regular notification: $e');
       onError?.call(e, st);
+      return null;
     }
-    return id;
   }
 
   @override
-  Future<int> showActionNotification({
+  Future<int?> showActionNotification({
     required String title,
     required String body,
     List<NotificationActionButton>? buttons,
@@ -416,7 +519,7 @@ class DefaultNotificationHandler extends NotificationWrapper {
     final id = _generateId();
     _logger.d('Showing action notification: "$title"');
     try {
-      await AwesomeNotifications().createNotification(
+      await _awesome.createNotification(
         content: NotificationContent(
           id: id,
           channelKey: channelKey ?? config.channelKey,
@@ -429,15 +532,16 @@ class DefaultNotificationHandler extends NotificationWrapper {
         ),
         actionButtons: buttons,
       );
+      return id;
     } catch (e, st) {
       _logger.e('Error showing action notification: $e');
       onError?.call(e, st);
+      return null;
     }
-    return id;
   }
 
   @override
-  Future<int> showReplyNotification({
+  Future<int?> showReplyNotification({
     required String title,
     required String body,
     String? replyLabel,
@@ -459,7 +563,7 @@ class DefaultNotificationHandler extends NotificationWrapper {
               actionType: ActionType.SilentBackgroundAction,
             ),
       ];
-      await AwesomeNotifications().createNotification(
+      await _awesome.createNotification(
         content: NotificationContent(
           id: id,
           channelKey: channelKey ?? config.channelKey,
@@ -473,11 +577,49 @@ class DefaultNotificationHandler extends NotificationWrapper {
         ),
         actionButtons: actionButtons,
       );
+      return id;
     } catch (e, st) {
       _logger.e('Error showing reply notification: $e');
       onError?.call(e, st);
+      return null;
     }
-    return id;
+  }
+
+  @override
+  Future<int?> showBigPictureNotification({
+    required String title,
+    required String body,
+    required String bigPicture,
+    String? largeIcon,
+    Map<String, String>? payload,
+    String? channelKey,
+  }) async {
+    await _ensureChannelsInitialized();
+    final config = _config ??= NotificationConfig.defaultConfig();
+    final id = _generateId();
+    _logger.d('Showing big-picture notification: "$title"');
+    try {
+      await _awesome.createNotification(
+        content: NotificationContent(
+          id: id,
+          channelKey: channelKey ?? config.channelKey,
+          title: title,
+          body: body,
+          payload: payload,
+          color: config.defaultColor,
+          wakeUpScreen: config.wakeUpScreen,
+          category: config.category,
+          notificationLayout: NotificationLayout.BigPicture,
+          bigPicture: bigPicture,
+          largeIcon: largeIcon,
+        ),
+      );
+      return id;
+    } catch (e, st) {
+      _logger.e('Error showing big-picture notification: $e');
+      onError?.call(e, st);
+      return null;
+    }
   }
 
   @override
@@ -489,11 +631,10 @@ class DefaultNotificationHandler extends NotificationWrapper {
     final config = _config ??= NotificationConfig.defaultConfig();
     _logger.d('Showing grouped notification (group: $groupKey)');
     final ids = <int>[];
-    try {
-      for (final messageContent in messages) {
-        final id = messageContent.id ?? _generateId();
-        ids.add(id);
-        await AwesomeNotifications().createNotification(
+    for (final messageContent in messages) {
+      final id = messageContent.id ?? _generateId();
+      try {
+        await _awesome.createNotification(
           content: NotificationContent(
             id: id,
             channelKey: messageContent.channelKey ?? config.channelKey,
@@ -509,16 +650,17 @@ class DefaultNotificationHandler extends NotificationWrapper {
             color: messageContent.color ?? config.defaultColor,
           ),
         );
+        ids.add(id);
+      } catch (e, st) {
+        _logger.e('Error showing grouped notification $id: $e');
+        onError?.call(e, st);
       }
-    } catch (e, st) {
-      _logger.e('Error showing grouped notifications: $e');
-      onError?.call(e, st);
     }
     return ids;
   }
 
   @override
-  Future<int> scheduleNotification({
+  Future<int?> scheduleNotification({
     required int id,
     required String title,
     required String body,
@@ -530,7 +672,7 @@ class DefaultNotificationHandler extends NotificationWrapper {
     final config = _config ??= NotificationConfig.defaultConfig();
     _logger.d('Scheduling notification ID $id: "$title" for $scheduledDate');
     try {
-      await AwesomeNotifications().createNotification(
+      await _awesome.createNotification(
         schedule: NotificationCalendar.fromDate(
           date: scheduledDate,
           allowWhileIdle: true,
@@ -546,45 +688,46 @@ class DefaultNotificationHandler extends NotificationWrapper {
           category: config.category ?? NotificationCategory.Reminder,
         ),
       );
+      return id;
     } catch (e, st) {
       _logger.e('Error scheduling notification: $e');
       onError?.call(e, st);
+      return null;
     }
-    return id;
   }
 
   @override
   Future<void> cancelNotification(int id) async {
     _logger.d('Cancelling notification ID: $id');
-    await AwesomeNotifications().cancel(id);
+    await _awesome.cancel(id);
   }
 
   @override
   Future<void> cancelAllNotifications() async {
     _logger.d('Cancelling all notifications.');
-    await AwesomeNotifications().cancelAll();
+    await _awesome.cancelAll();
   }
 
   @override
   Future<void> updateBadgeCount(int count) async {
     _logger.d('Updating badge count to: $count');
-    await AwesomeNotifications().setGlobalBadgeCounter(count);
+    await _awesome.setGlobalBadgeCounter(count);
   }
 
   @override
   Future<void> clearBadgeCount() async {
     _logger.d('Clearing badge count.');
-    await AwesomeNotifications().resetGlobalBadge();
+    await _awesome.resetGlobalBadge();
   }
 
   @override
   Future<void> openNotificationSettings() async {
     _logger.d('Opening notification settings.');
-    await AwesomeNotifications().showNotificationConfigPage();
+    await _awesome.showNotificationConfigPage();
   }
 
   @override
-  Future<int> simulateNotification({
+  Future<int?> simulateNotification({
     required String title,
     required String body,
     Map<String, dynamic>? data,
@@ -610,6 +753,10 @@ class DefaultNotificationHandler extends NotificationWrapper {
     }
     _notificationDebouncer.cancel();
     _permissionStatus.dispose();
+    unawaited(_foregroundMessageController.close());
+    unawaited(_messageOpenedController.close());
+    unawaited(_actionController.close());
+    unawaited(_tokenRefreshController.close());
   }
 
   // ================== PERMISSIONS ===================
@@ -624,21 +771,20 @@ class DefaultNotificationHandler extends NotificationWrapper {
     _logger.i('Requesting notification permissions...');
 
     try {
-      var settings = await FirebaseMessaging.instance.getNotificationSettings();
+      var settings = await _messaging.getNotificationSettings();
       _permissionStatus.value = settings.authorizationStatus;
 
       if (settings.authorizationStatus == AuthorizationStatus.notDetermined ||
           settings.authorizationStatus == AuthorizationStatus.denied) {
-        settings = await FirebaseMessaging.instance.requestPermission();
+        settings = await _messaging.requestPermission();
         _permissionStatus.value = settings.authorizationStatus;
         onPermissionEvent?.call('notification_permission_fcm_request', {
           'status': settings.authorizationStatus.toString(),
         });
       }
 
-      if (!await AwesomeNotifications().isNotificationAllowed()) {
-        final granted =
-            await AwesomeNotifications().requestPermissionToSendNotifications(
+      if (!await _awesome.isNotificationAllowed()) {
+        final granted = await _awesome.requestPermissionToSendNotifications(
           channelKey: _config?.channelKey,
           permissions: const [
             NotificationPermission.Alert,
@@ -666,13 +812,12 @@ class DefaultNotificationHandler extends NotificationWrapper {
   }
 
   @override
-  Future<bool> isNotificationAllowed() =>
-      AwesomeNotifications().isNotificationAllowed();
+  Future<bool> isNotificationAllowed() => _awesome.isNotificationAllowed();
 
   // ================== AWESOME EVENT LISTENERS ===================
 
   Future<void> _startListeningAwesomeNotificationEvents() async {
-    await AwesomeNotifications().setListeners(
+    await _awesome.setListeners(
       onActionReceivedMethod: _onActionReceivedMethod,
       onNotificationCreatedMethod: _onNotificationCreatedMethod,
       onNotificationDisplayedMethod: _onNotificationDisplayedMethod,
@@ -708,7 +853,11 @@ class DefaultNotificationHandler extends NotificationWrapper {
   static Future<void> _onActionReceivedImplementation(
     ReceivedAction receivedAction,
   ) async {
-    await DefaultNotificationHandler.I.handleActionReceived(receivedAction);
+    final handler = DefaultNotificationHandler.I;
+    if (!handler._actionController.isClosed) {
+      handler._actionController.add(receivedAction);
+    }
+    await handler.handleActionReceived(receivedAction);
   }
 
   static Future<void> _initializeIsolateReceivePort() async {

--- a/lib/src/notification_wrapper.dart
+++ b/lib/src/notification_wrapper.dart
@@ -11,13 +11,16 @@ import 'utils/logger.dart';
 /// Abstract contract for a unified Firebase Cloud Messaging +
 /// AwesomeNotifications handler.
 ///
-/// The concrete [DefaultNotificationHandler] implements every method below.
+/// The concrete [DefaultNotificationHandler] implements every member below.
 /// Consumers normally use that implementation via
 /// [DefaultNotificationHandler.initializeSharedInstance]; this abstraction
 /// exists so the behavior can be swapped or faked in tests.
 ///
-/// All message/notification lifecycle callbacks can be overridden through the
-/// constructor. Anything not overridden falls back to a logging-only default.
+/// You can react to events two ways:
+///  * **Streams** ([onForegroundMessage], [onMessageOpened], [onActionReceived],
+///    [onTokenRefresh]) — listen from anywhere, anytime.
+///  * **Constructor overrides** — pass `onMessageOverride`, etc. for a single
+///    centralized handler. Anything not overridden falls back to logging.
 abstract class NotificationWrapper {
   /// Creates a wrapper, optionally overriding lifecycle callbacks.
   NotificationWrapper({
@@ -76,37 +79,62 @@ abstract class NotificationWrapper {
     bool requestPermissionsOnInit = false,
   });
 
-  // ================== FCM TOKEN METHODS ===================
-  Future<String?> getFcmToken();
+  // ================== EVENT STREAMS ===================
+  // Broadcast streams — listen from anywhere. Prefer these over the constructor
+  // overrides when you need to react from multiple places in the app.
 
-  /// Registers [onTokenRefresh] to be called whenever the FCM token changes.
-  ///
-  /// Idempotent: calling this repeatedly replaces the previous callback rather
-  /// than stacking subscriptions.
-  Future<void> refreshToken(void Function(String) onTokenRefresh);
+  /// Foreground FCM messages.
+  Stream<RemoteMessage> get onForegroundMessage;
+
+  /// FCM messages whose notification was tapped to bring the app to the
+  /// foreground (from background, not terminated — see [getInitialMessage]).
+  Stream<RemoteMessage> get onMessageOpened;
+
+  /// User interactions (taps / action buttons) on AwesomeNotifications.
+  Stream<ReceivedAction> get onActionReceived;
+
+  /// FCM device-token refreshes. Send the new token to your server here.
+  Stream<String> get onTokenRefresh;
+
+  // ================== COLD-START / DEEP LINK ===================
+
+  /// The FCM message that launched the app from a terminated state by tapping
+  /// its notification, or `null` if the app was not launched that way. Call once
+  /// after [initialize] to deep-link from a cold start.
+  Future<RemoteMessage?> getInitialMessage();
+
+  /// The notification action that launched the app from a terminated state, or
+  /// `null`. Use to deep-link from a tapped local notification on cold start.
+  Future<ReceivedAction?> getInitialAction();
+
+  // ================== FCM TOKEN & TOPICS ===================
+  Future<String?> getFcmToken();
+  Future<void> subscribeToTopic(String topic);
+  Future<void> unsubscribeFromTopic(String topic);
 
   // ================== NOTIFICATION PERMISSIONS ===================
   Future<AuthorizationStatus> requestPermissions();
   Future<bool> isNotificationAllowed();
 
   // ================== NOTIFICATION DISPLAY ===================
-  // Display methods return the generated notification id so callers can later
-  // cancel or update the notification they created.
-  Future<int> showNotification(RemoteMessage message);
-  Future<int> showRegularNotification({
+  // Display methods return the generated notification id on success, or `null`
+  // if the platform failed to create the notification — so the return value is
+  // an honest success signal you can later pass to [cancelNotification].
+  Future<int?> showNotification(RemoteMessage message);
+  Future<int?> showRegularNotification({
     required String title,
     required String body,
     Map<String, String>? payload,
     String? channelKey,
   });
-  Future<int> showActionNotification({
+  Future<int?> showActionNotification({
     required String title,
     required String body,
     List<NotificationActionButton> buttons,
     Map<String, String>? payload,
     String? channelKey,
   });
-  Future<int> showReplyNotification({
+  Future<int?> showReplyNotification({
     required String title,
     required String body,
     String? replyLabel,
@@ -114,11 +142,22 @@ abstract class NotificationWrapper {
     Map<String, String>? payload,
     String? channelKey,
   });
+
+  /// Shows a big-picture notification. [bigPicture] is an AwesomeNotifications
+  /// resource (e.g. `asset://...`, `resource://...`, `file://...`, or a URL).
+  Future<int?> showBigPictureNotification({
+    required String title,
+    required String body,
+    required String bigPicture,
+    String? largeIcon,
+    Map<String, String>? payload,
+    String? channelKey,
+  });
   Future<List<int>> showGroupedNotification(
     String groupKey,
     List<NotificationContent> messages,
   );
-  Future<int> scheduleNotification({
+  Future<int?> scheduleNotification({
     required int id,
     required String title,
     required String body,
@@ -135,15 +174,15 @@ abstract class NotificationWrapper {
 
   // ================== SETTINGS & DEBUG ===================
   Future<void> openNotificationSettings();
-  Future<int> simulateNotification({
+  Future<int?> simulateNotification({
     required String title,
     required String body,
     Map<String, dynamic>? data,
     String? channelKey,
   });
 
-  /// Cancels listeners and releases resources. Call when the handler is no
-  /// longer needed (e.g. on logout or app teardown).
+  /// Cancels listeners, closes streams and releases resources. Call when the
+  /// handler is no longer needed (e.g. on logout or app teardown).
   void dispose();
 
   // ================== STATIC DEFAULT HANDLERS ===================

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,10 +1,9 @@
 name: flutter_notification_wrapper
 description: A unified interface over Firebase Cloud Messaging and AwesomeNotifications with background handling, action buttons, scheduling, grouping, badges and channel configuration.
-version: 1.0.0
+version: 1.0.0-beta.1
 homepage: https://github.com/antsf/flutter_notification_wrapper
 repository: https://github.com/antsf/flutter_notification_wrapper.git
 issue_tracker: https://github.com/antsf/flutter_notification_wrapper/issues
-documentation: https://github.com/antsf/flutter_notification_wrapper/wiki
 
 environment:
   sdk: '>=3.0.0 <4.0.0'

--- a/test/handler_behavior_test.dart
+++ b/test/handler_behavior_test.dart
@@ -1,0 +1,141 @@
+import 'package:awesome_notifications/awesome_notifications.dart';
+import 'package:firebase_messaging/firebase_messaging.dart';
+import 'package:flutter_notification_wrapper/flutter_notification_wrapper.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockAwesomeNotifications extends Mock implements AwesomeNotifications {}
+
+class MockFirebaseMessaging extends Mock implements FirebaseMessaging {}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(<NotificationChannel>[]);
+    registerFallbackValue(
+      NotificationContent(id: 0, channelKey: 'fallback'),
+    );
+  });
+
+  late MockAwesomeNotifications awesome;
+
+  setUp(() {
+    DefaultNotificationHandler.resetInstance();
+    awesome = MockAwesomeNotifications();
+    when(() => awesome.initialize(any(), any(), debug: any(named: 'debug')))
+        .thenAnswer((_) async => true);
+  });
+
+  tearDown(DefaultNotificationHandler.resetInstance);
+
+  group('show* behaviour (B3/B4)', () {
+    test('showRegularNotification creates on the config channel and returns id',
+        () async {
+      when(() => awesome.createNotification(content: any(named: 'content')))
+          .thenAnswer((_) async => true);
+
+      final handler = DefaultNotificationHandler.createForTest(
+        awesomeNotifications: awesome,
+        config: const NotificationConfig(
+          channelKey: 'chat_channel',
+          channelName: 'Chat',
+        ),
+      );
+
+      final id = await handler.showRegularNotification(title: 't', body: 'b');
+
+      expect(id, isNotNull);
+      final content = verify(
+        () => awesome.createNotification(content: captureAny(named: 'content')),
+      ).captured.single as NotificationContent;
+      expect(content.channelKey, 'chat_channel');
+      expect(content.id, id);
+      expect(content.title, 't');
+    });
+
+    test('show* returns null and reports onError when the platform fails',
+        () async {
+      when(() => awesome.createNotification(content: any(named: 'content')))
+          .thenThrow(Exception('platform failure'));
+
+      Object? reported;
+      final handler = DefaultNotificationHandler.createForTest(
+        awesomeNotifications: awesome,
+        config: const NotificationConfig(channelKey: 'c', channelName: 'C'),
+        onError: (error, _) => reported = error,
+      );
+
+      final id = await handler.showRegularNotification(title: 't', body: 'b');
+
+      expect(id, isNull, reason: 'failed notification must not return an id');
+      expect(reported, isA<Exception>());
+    });
+
+    test('channel setup reflects NotificationConfig (silent -> Min/no sound)',
+        () async {
+      when(() => awesome.createNotification(content: any(named: 'content')))
+          .thenAnswer((_) async => true);
+
+      final handler = DefaultNotificationHandler.createForTest(
+        awesomeNotifications: awesome,
+        config: NotificationConfig.silent(
+          channelKey: 'silent_channel',
+          channelName: 'Silent',
+        ),
+      );
+
+      // First show triggers lazy channel initialization.
+      await handler.showRegularNotification(title: 't', body: 'b');
+
+      final channels = verify(
+        () => awesome.initialize(
+          any(),
+          captureAny(),
+          debug: any(named: 'debug'),
+        ),
+      ).captured.single as List<NotificationChannel>;
+      final main = channels.firstWhere((c) => c.channelKey == 'silent_channel');
+      expect(main.importance, NotificationImportance.Min);
+      expect(main.playSound, isFalse);
+      expect(main.channelShowBadge, isFalse);
+    });
+  });
+
+  group('FCM topics + cold start (B1/C1)', () {
+    test(
+        'subscribeToTopic / unsubscribeFromTopic delegate to FirebaseMessaging',
+        () async {
+      final messaging = MockFirebaseMessaging();
+      when(() => messaging.subscribeToTopic(any())).thenAnswer((_) async {});
+      when(() => messaging.unsubscribeFromTopic(any()))
+          .thenAnswer((_) async {});
+
+      final handler = DefaultNotificationHandler.createForTest(
+        awesomeNotifications: awesome,
+        firebaseMessaging: messaging,
+        config: const NotificationConfig(channelKey: 'c', channelName: 'C'),
+      );
+
+      await handler.subscribeToTopic('news');
+      await handler.unsubscribeFromTopic('news');
+
+      verify(() => messaging.subscribeToTopic('news')).called(1);
+      verify(() => messaging.unsubscribeFromTopic('news')).called(1);
+    });
+
+    test('getInitialAction returns null gracefully when none / on error',
+        () async {
+      when(() => awesome.getInitialNotificationAction())
+          .thenAnswer((_) async => null);
+      final handler = DefaultNotificationHandler.createForTest(
+        awesomeNotifications: awesome,
+        config: const NotificationConfig(channelKey: 'c', channelName: 'C'),
+      );
+
+      expect(await handler.getInitialAction(), isNull);
+
+      when(() => awesome.getInitialNotificationAction())
+          .thenThrow(Exception('boom'));
+      expect(await handler.getInitialAction(), isNull);
+    });
+  });
+}


### PR DESCRIPTION
Implements the gatekeeper action plan in [`analysis/09-gatekeeper-review.md`](analysis/09-gatekeeper-review.md) — Phases A + B + C — and re-versions to **`1.0.0-beta.1`** to gather real-world feedback before a stable `1.0.0`. Contains **breaking API additions**.

## Phase A — publish cleanup
- Removed the broken `documentation:` wiki link from `pubspec.yaml`.
- Fixed CHANGELOG placeholder dates; trimmed README overclaims; added a beta/platform status note.
- CI `actions/checkout@v4` → `@v5` (Node 20 deprecation).
- Version `1.0.0` → `1.0.0-beta.1`.

## Phase B — earn "recommendable"
- **Event streams** — `onForegroundMessage`, `onMessageOpened`, `onActionReceived`, `onTokenRefresh` (replaces the `refreshToken(callback)` API).
- **Cold-start deep links** — `getInitialMessage()` / `getInitialAction()`.
- **Honest results** — `show*` / `scheduleNotification` now return `Future<int?>` (null on platform failure); `showGroupedNotification` returns the ids actually created.
- **Injectable plugin seam** — `AwesomeNotifications` / `FirebaseMessaging` are injectable (`@visibleForTesting createForTest`), enabling **real handler tests** (mocktail): create-on-config-channel, return-null-on-failure, channel-reflects-config, topic + cold-start delegation.
- **Terminated-state verification** — example integration smoke test + a documented manual procedure ([`VERIFICATION.md`](VERIFICATION.md)) + known-limitations note.

## Phase C — differentiation
- **FCM topics** — `subscribeToTopic()` / `unsubscribeFromTopic()`.
- **`showBigPictureNotification()`** rich-layout helper.

## Breaking changes (see [CHANGELOG](CHANGELOG.md))
- `refreshToken(callback)` removed → use the `onTokenRefresh` stream.
- `show*` / `scheduleNotification` return `Future<int?>` (was `Future<int>`).

## Verification (local)
- `dart format --set-exit-if-changed` → OK
- `flutter analyze` (lib + test + example + integration_test) → No issues found
- `flutter test` → **57 passed** (was 52; +5 real handler-behavior tests)
- `dart pub publish --dry-run` → 0 content warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)